### PR TITLE
Add feature to save histograms

### DIFF
--- a/LJMet/interface/BaseEventSelector.h
+++ b/LJMet/interface/BaseEventSelector.h
@@ -99,6 +99,7 @@ public:
     /// Declare a new histogram to be created for the module
     void SetHistogram(std::string name, int nbins, double low, double high) { mpEc->SetHistogram(mName, name, nbins, low, high); }
     void SetHistValue(std::string name, double value) { mpEc->SetHistValue(mName, name, value); }
+    void FillHist(std::string name, double value) { mpEc->FillHist(mName, name, value); }
     
             
 protected:

--- a/LJMet/interface/LjmetEventContent.h
+++ b/LJMet/interface/LjmetEventContent.h
@@ -75,6 +75,7 @@ public:
     
     /// Assign current hist value to hist metadata collection
     void SetHistValue(std::string modname, std::string histname, double value);
+    void FillHist(std::string modname, std::string histname, double value);
     void Fill();
     
 private:

--- a/LJMet/plugins/BaseEventSelector.cc
+++ b/LJMet/plugins/BaseEventSelector.cc
@@ -36,10 +36,11 @@ void BaseEventSelector::EndEvent(edm::EventBase const & event, LjmetEventContent
 void BaseEventSelector::Init( void )
 {
 
-	// NOTE: These are used by Jets correction methods and BTag methods, but probably these can be re organized too. 
-    // init sanity check histograms 
-    mpEc->SetHistogram(mName, "jes_correction", 100, 0.8, 1.2);
-    mpEc->SetHistogram(mName, "met_correction", 100, 0.0, 2.0);
-    mpEc->SetHistogram(mName, "nBtagSfCorrections", 100, 0.0, 10.0);
+	// NOTE: These are used by Jets correction methods and BTag methods, but probably these can be re organized too.
+    // init sanity check histograms --> ACTUALLY, CAN REMOVE THESE, MAR 15, 2019
+//     mpEc->SetHistogram(mName, "jes_correction", 100, 0.8, 1.2);
+//     mpEc->SetHistogram(mName, "met_correction", 100, 0.0, 2.0);
+//     mpEc->SetHistogram(mName, "nBtagSfCorrections", 100, 0.0, 10.0);
+    mpEc->SetHistogram(mName, "nEvents", 4, -2,2); // to record total events prior to any selection (and ideally negative weights for MC). 
 }
 

--- a/LJMet/plugins/BaseEventSelector.cc
+++ b/LJMet/plugins/BaseEventSelector.cc
@@ -36,11 +36,7 @@ void BaseEventSelector::EndEvent(edm::EventBase const & event, LjmetEventContent
 void BaseEventSelector::Init( void )
 {
 
-	// NOTE: These are used by Jets correction methods and BTag methods, but probably these can be re organized too.
-    // init sanity check histograms --> ACTUALLY, CAN REMOVE THESE, MAR 15, 2019
-//     mpEc->SetHistogram(mName, "jes_correction", 100, 0.8, 1.2);
-//     mpEc->SetHistogram(mName, "met_correction", 100, 0.0, 2.0);
-//     mpEc->SetHistogram(mName, "nBtagSfCorrections", 100, 0.0, 10.0);
     mpEc->SetHistogram(mName, "nEvents", 4, -2,2); // to record total events prior to any selection (and ideally negative weights for MC). 
+
 }
 

--- a/LJMet/plugins/LJMet.cc
+++ b/LJMet/plugins/LJMet.cc
@@ -167,7 +167,7 @@ LJMet::LJMet(const edm::ParameterSet& iConfig)
         TFileDirectory _dir = fs->mkdir( iMod->first.c_str() );
         for (iHist=iMod->second.begin();iHist!=iMod->second.end();++iHist){
             std::cout << "[FWLJMet] : "
-            << "Creating " << iMod->first << "/"
+            << "Creating histograms : " << iMod->first << "/"
             << iHist->second.GetName() << std::endl;
             iHist->second.SetHist( _dir.make<TH1F>(iHist->second.GetName().c_str(),
                                                    iHist->second.GetName().c_str(),

--- a/LJMet/plugins/LJMet.cc
+++ b/LJMet/plugins/LJMet.cc
@@ -158,6 +158,26 @@ LJMet::LJMet(const edm::ParameterSet& iConfig)
    // set excluded calculators
    factory->SetExcludedCalcs(vExcl); 
    
+   // create histograms
+   std::map<std::string,std::map<std::string,LjmetEventContent::HistMetadata> > & mh = ec.GetHistMap();
+   std::map<std::string,std::map<std::string,LjmetEventContent::HistMetadata> >::iterator iMod;
+   std::map<std::string,LjmetEventContent::HistMetadata>::iterator iHist;
+   for (iMod=mh.begin();iMod!=mh.end();++iMod){
+        
+        TFileDirectory _dir = fs->mkdir( iMod->first.c_str() );
+        for (iHist=iMod->second.begin();iHist!=iMod->second.end();++iHist){
+            std::cout << "[FWLJMet] : "
+            << "Creating " << iMod->first << "/"
+            << iHist->second.GetName() << std::endl;
+            iHist->second.SetHist( _dir.make<TH1F>(iHist->second.GetName().c_str(),
+                                                   iHist->second.GetName().c_str(),
+                                                   iHist->second.GetNBins(),
+                                                   iHist->second.GetXMin(),
+                                                   iHist->second.GetXMax() 
+                                                   ) 
+                                  );
+        }
+    }
 
 
 }

--- a/LJMet/plugins/LjmetEventContent.cc
+++ b/LJMet/plugins/LjmetEventContent.cc
@@ -134,6 +134,41 @@ void LjmetEventContent::SetHistValue(std::string modname, std::string histname, 
     }
 }
 
+void LjmetEventContent::FillHist(std::string modname, std::string histname, double value)
+{
+
+    // fill histograms
+    std::map<std::string, std::map<std::string, LjmetEventContent::HistMetadata>>::iterator iMod;
+    std::map<std::string, LjmetEventContent::HistMetadata>::iterator iHist;
+    for (iMod = mDoubleHist.begin(); iMod != mDoubleHist.end(); ++iMod) {
+    	if(iMod->first == modname){    			
+			for (iHist = iMod->second.begin(); iHist != iMod->second.end(); ++iHist) {
+    			if(iHist->first==histname){
+					TH1 * _hist = iHist->second.GetHist();
+					if (_hist){
+						_hist->Fill(value);
+						if(mVerbosity>1) std::cout << mLegend <<"["+modname+"]:"<<"Filling "+histname+" histogram" << std::endl;
+					}
+					else{
+						std::cout << mLegend <<"Histo "+histname+" is NULL" << std::endl;
+					}
+					break; // end loop when map of histo is found
+				}
+				else if (iHist == iMod->second.end()){
+					std::cout << mLegend <<"["+modname+"]:"<<"Problem finding map of of histo for this module" << std::endl;
+				}
+			}
+			break; //end loop when map of map of histo is found
+		}
+		else if(iMod == mDoubleHist.end()){
+			std::cout << mLegend <<"["+modname+"]:"<<"Problem finding map of map of histo for this module" << std::endl;		
+		}
+
+    }
+
+}
+
+
 void LjmetEventContent::Fill()
 {
     if (mFirstEntry) {
@@ -142,8 +177,8 @@ void LjmetEventContent::Fill()
     }
     mpTree->Fill();
     
-    // fill histograms
-    // create histograms
+    // fill histograms --> Replaced by FillHist !! Now we fill each histogram one at a time individually, not all at once.
+    /*
     std::map<std::string, std::map<std::string, LjmetEventContent::HistMetadata>>::iterator iMod;
     std::map<std::string, LjmetEventContent::HistMetadata>::iterator iHist;
     for (iMod = mDoubleHist.begin(); iMod != mDoubleHist.end(); ++iMod) {
@@ -152,6 +187,7 @@ void LjmetEventContent::Fill()
             if (_hist) _hist->Fill(iHist->second.GetValue());
         }
     }
+    */
 }
 
 int LjmetEventContent::createBranches()

--- a/LJMet/plugins/MultiLepEventSelector.cc
+++ b/LJMet/plugins/MultiLepEventSelector.cc
@@ -205,8 +205,6 @@ private:
 
     //JET correction methods variables/parameters/object type definitions - Ideally THESE NEEDS TO BE ON A SEPARATE DEDICATED JET CORRENTION CLASS, or something like that. - but on top of that this needs to be optimized and rewritten.
 
-    int mNCorrJets; // used in correctJet method
-
     TRandom3 JERrand;
 
     std::string MCL1JetPar;
@@ -320,8 +318,6 @@ private:
     BTagCalibration       calibsj;
     BTagCalibrationReader reader;
     BTagCalibrationReader readerSJ;
-
-    int mNBtagSfCorrJets; // used in isJetTagged method
 
     // ---------------------------------------------------------------
     // ---------------------------------------------------------------
@@ -2171,19 +2167,7 @@ TLorentzVector MultiLepEventSelector::correctJet(const pat::Jet & jet,
 
   TLorentzVector jetP4;
   jetP4.SetPtEtaPhiM(correctedJet.pt(), correctedJet.eta(),correctedJet.phi(), correctedJet.mass() );
-  //std::cout<<"jet pt: "<<jetP4.Pt()<<" eta: "<<jetP4.Eta()<<" phi: "<<jetP4.Phi()<<" energy: "<<jetP4.E()<<std::endl;
 
-
-  // sanity check - save correction of the first jet
-  if (mNCorrJets==0){
-    double _orig_pt = jet.pt();
-    if (fabs(_orig_pt)<0.000000001){
-      _orig_pt = 0.000000001;
-    }
-    SetHistValue("jes_correction", jetP4.Pt()/_orig_pt);
-    ++mNCorrJets;
-  }
-  //if (jetP4.Pt()>30.) std::cout<<"JEC Ratio (new/old) = "<<jetP4.Pt()/jet.pt()<<"     -->    corrected pT / eta = "<<jetP4.Pt()<<" / "<<jetP4.Eta()<<std::endl;
 
   return jetP4;
 }
@@ -2390,12 +2374,6 @@ TLorentzVector MultiLepEventSelector::correctMet(const pat::MET & met, edm::Even
 
     correctedMET_p4.SetPxPyPzE(correctedMET_px, correctedMET_py, 0, sqrt(correctedMET_px*correctedMET_px+correctedMET_py*correctedMET_py));
 
-    // sanity check histogram
-    double _orig_met = met.pt();
-    if (fabs(_orig_met) < 1.e-9) {
-        _orig_met = 1.e-9;
-    }
-    SetHistValue("met_correction", correctedMET_p4.Pt()/_orig_met);
 
     return correctedMET_p4;
 }
@@ -2623,9 +2601,11 @@ bool MultiLepEventSelector::isJetTagged(const pat::Jet & jet,
       mBtagSfUtil.SetSeed(abs(static_cast<int>(sin(jet.phi())*1e5)));
 
       // sanity check
+      /*
       bool _orig_tag = _isTagged;
       mBtagSfUtil.modifyBTagsWithSF(_isTagged, _jetFlavor, _heavySf, _heavyEff, _lightSf, _lightEff);
       if (_isTagged != _orig_tag) ++mNBtagSfCorrJets;
+      */
 
     } // end of btag scale factor corrections
 

--- a/LJMet/plugins/MultiLepEventSelector.cc
+++ b/LJMet/plugins/MultiLepEventSelector.cc
@@ -797,15 +797,15 @@ void MultiLepEventSelector::BeginJob( const edm::ParameterSet& iConfig, edm::Con
     set("All cuts",true);
     
     //Record cut flow information - will be saved under folder named after the selector name.
-    SetHistogram( "Trigger", 1, 0,1); 
-    SetHistogram("Primary Vertex", 1, 0,1); 
-    SetHistogram("MET filters", 1, 0,1); 
-    SetHistogram("Lepton Selection", 1, 0,1); // keeping it simple for now
+    SetHistogram( "Trigger", 2, 0,2); 
+    SetHistogram("Primary Vertex", 2, 0,2); 
+    SetHistogram("MET filters", 2, 0,2); 
+    SetHistogram("Lepton Selection", 2, 0,2); // keeping it simple for now
     if(jet_cuts){ 
-		SetHistogram("Jet Selection", 1, 0,1); // keeping it simple for now
+		SetHistogram("Jet Selection", 2, 0,2); // keeping it simple for now
     }
-    SetHistogram("MET", 1, 0,1); 
-    SetHistogram("All cuts", 1, 0,1); 
+    SetHistogram("MET", 2, 0,2); 
+    SetHistogram("All cuts", 2, 0,2); 
     
 
 
@@ -826,7 +826,7 @@ bool MultiLepEventSelector::operator()( edm::Event const & event, pat::strbitset
       event.getByToken(genToken, genEvtInfo );
       theWeight = genEvtInfo->weight()/fabs(genEvtInfo->weight());
    }
-  SetHistValue("nEvents", theWeight);
+  FillHist("nEvents", theWeight);
 
   while(1){ // standard infinite while loop trick to avoid nested ifs
 
@@ -834,37 +834,37 @@ bool MultiLepEventSelector::operator()( edm::Event const & event, pat::strbitset
 
     if( ! TriggerSelection(event) ) break; 
     passCut(ret, "Trigger");
-    SetHistValue("Trigger", 1);
+    FillHist("Trigger", 1);
 
     if( ! PVSelection(event) ) break;
     passCut(ret, "Primary Vertex");
-    SetHistValue("Primary Vertex", 1);
+    FillHist("Primary Vertex", 1);
 
     if( ! METfilter(event) ) break;
     passCut(ret, "MET filters");
-    SetHistValue("Primary Vertex", 1);
+    FillHist("MET filters", 1);
 
     //Collect selected leptons
     MuonSelection(event);
     ElectronSelection(event);
 
     if( ! LeptonsSelection(event, ret) ) break;
-    SetHistValue("Lepton Selection", 1); // keeping it simple for now
+    FillHist("Lepton Selection", 1); // keeping it simple for now
 
     //Collect jets
     if( ! JetSelection(event, ret) ) break;
-    SetHistValue("Jet Selection", 1); // keeping it simple for now
+    FillHist("Jet Selection", 1); // keeping it simple for now
 
     //Collect AK8 jets
     AK8JetSelection(event);
 
     if( ! METSelection(event) ) break;
     passCut(ret, "MET");
-    SetHistValue("MET", 1);
+    FillHist("MET", 1);
 
 
     passCut(ret, "All cuts");
-    SetHistValue("All cuts", 1); 
+    FillHist("All cuts", 1); 
     break;
 
   } // end of while loop


### PR DESCRIPTION
Update:
 - Added feature to save histograms, eg. cutflow, etc.
- To do this, a new method FillHist is added in LjmetEventContent and BaseEventSelector and
- Fill method in LjmetEventContent is modified such that now it does not Fill all registered histograms at once at the end of only selected events but each histograms is filled by invoking FillHist for possibly any processed event.