### PR TITLE
Compartmentalizing btagging

### DIFF
--- a/LJMet/interface/BTagSFUtil.h
+++ b/LJMet/interface/BTagSFUtil.h
@@ -16,8 +16,9 @@
  Contact: michael.segala@gmail.com
  Updated: Ulrich Heintz 12/23/2011
  Updated: Gena Kukartsev 10/30/2012
+ Updated: Rizki Syarif 03/19/2019 : Made this class handle everything to do with Btagging.
  
- v 1.2
+ v 2.0
  
  *************************************************************/
 
@@ -29,6 +30,15 @@
 #include "TRandom3.h"
 #include "TMath.h"
 
+#include "FWLJMET/LJMet/interface/BaseEventSelector.h"
+#include "FWLJMET/LJMet/interface/LjmetFactory.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWLJMET/LJMet/interface/BtagHardcodedConditions.h"
+#include "CondFormats/BTauObjects/interface/BTagCalibration.h"
+#include "CondTools/BTau/interface/BTagCalibrationReader.h"
+
 
 class BTagSFUtil{
     
@@ -37,6 +47,8 @@ public:
     BTagSFUtil();
     BTagSFUtil(int seed);
     ~BTagSFUtil();
+
+    void Initialize(const edm::ParameterSet& iConfig);
     
     void modifyBTagsWithSF( bool& isBTagged,
                            int pdgIdPart,
@@ -47,12 +59,40 @@ public:
     
     void SetSeed( int seed );
     
+
+    bool isJetTagged(const pat::Jet &jet,
+                     TLorentzVector correctedJet_lv,
+                     edm::Event const & event,
+                     bool isMc,
+                     int shiftflag = 0,
+                     bool subjetflag = false);
+
+
     
 private:
+    
+    bool debug;
+    std::string mLegend = "\t[BTagSFUtil]: ";
     
     bool applySF(bool& isBTagged, float Btag_SF = 0.98, float Btag_eff = 1.0);
     
     TRandom3 rand_;
+
+    double      bdisc_min;
+    std::string DeepCSVfile;
+    std::string DeepCSVSubjetfile;
+    std::string btagOP;
+    double      applyBtagSF;
+    bool        BTagUncertUp;
+    bool        BTagUncertDown;
+    bool        MistagUncertUp;
+    bool        MistagUncertDown;
+    BtagHardcodedConditions mBtagCond;
+    BTagCalibration       calib;
+    BTagCalibration       calibsj;
+    BTagCalibrationReader reader;
+    BTagCalibrationReader readerSJ;
+
     
 };
 

--- a/LJMet/interface/JetMETCorrHelper.h
+++ b/LJMet/interface/JetMETCorrHelper.h
@@ -66,9 +66,9 @@ class JetMETCorrHelper{
 
     private:
             
-        bool debug=true;
+        bool debug;
 
-        std::string mLegend = "[JetMETCorrHelper]: ";
+        std::string mLegend = "\t[JetMETCorrHelper]: ";
     
         TRandom3 JERrand;
 

--- a/LJMet/plugins/JetMETCorrHelper.cc
+++ b/LJMet/plugins/JetMETCorrHelper.cc
@@ -18,7 +18,9 @@ JetMETCorrHelper::JetMETCorrHelper(const edm::ParameterSet& iConfig, bool isMc)
 void JetMETCorrHelper::Initialize(const edm::ParameterSet& iConfig, bool isMc){
 
     //JET CORRECTION  initialization
-    if(debug) std::cout << mLegend << "Initializing JetMETCorrHelper object." << std::endl;
+    std::cout << mLegend << "Initializing JetMETCorrHelper object." << std::endl;
+
+    debug              = iConfig.getParameter<bool>("debug");
 
     std::string JEC_txtfile              = iConfig.getParameter<std::string>("JEC_txtfile");
     std::string JERSF_txtfile            = iConfig.getParameter<std::string>("JERSF_txtfile");
@@ -193,7 +195,7 @@ TLorentzVector JetMETCorrHelper::correctJet(const pat::Jet & jet,
   pat::Jet correctedJet = correctJetReturnPatJet(jet, event, isMc, rhoJetsToken, doAK8Corr, reCorrectJet, syst);
 
   TLorentzVector jetP4;
-  jetP4.SetPtEtaPhiM(correctedJet.pt(), correctedJet.eta(),correctedJet.phi(), correctedJet.mass() );
+  jetP4.SetPtEtaPhiM(correctedJet.pt(), correctedJet.eta(),correctedJet.phi(), correctedJet.mass() ); // Should this use SetPtEtaPhiE ? -- Mar 19, 2019.
 
 
   return jetP4;

--- a/LJMet/runFWLJMet_multiLep.py
+++ b/LJMet/runFWLJMet_multiLep.py
@@ -281,14 +281,15 @@ process.ljmet = cms.EDAnalyzer(
 
             #Btag
             btag_cuts                = cms.bool(False), #not implemented
-            btagOP                   = cms.string('MEDIUM'),
-            bdisc_min                = cms.double(0.4941),
+            btagOP                   = cms.string('MEDIUM'), 
+            bdisc_min                = cms.double(0.4941), # THIS HAS TO MATCH btagOP !
+            applyBtagSF              = cms.bool(True), #This is implemented by BTagSFUtil.cc
             DeepCSVfile              = cms.string(relBase+'/src/FWLJMET/LJMet/data/DeepCSV_94XSF_V3_B_F.csv'),
             DeepCSVSubjetfile        = cms.string(relBase+'/src/FWLJMET/LJMet/data/subjet_DeepCSV_94XSF_V3_B_F.csv'),
-            BTagUncertUp             = cms.bool(False), # no longer needed
-            BTagUncertDown           = cms.bool(False), # no longer needed
-            MistagUncertUp           = cms.bool(False), # no longer needed
-            MistagUncertDown          = cms.bool(False), # no longer needed
+            BTagUncertUp             = cms.bool(False), # no longer needed, but can still be utilized. Keep false as default.
+            BTagUncertDown           = cms.bool(False), # no longer needed, but can still be utilized. Keep false as default.
+            MistagUncertUp           = cms.bool(False), # no longer needed, but can still be utilized. Keep false as default.
+            MistagUncertDown          = cms.bool(False), # no longer needed, but can still be utilized. Keep false as default.
 
 
             ),
@@ -352,6 +353,16 @@ process.ljmet = cms.EDAnalyzer(
             keepStatusForce    = cms.vuint32(62,22),
             cleanGenJets       = cms.bool(True),
             
+            #Btagging
+            btagOP                   = cms.string('MEDIUM'), 
+            bdisc_min                = cms.double(0.4941), # THIS HAS TO MATCH btagOP !
+            applyBtagSF              = cms.bool(True), #This is implemented by BTagSFUtil.cc
+            DeepCSVfile              = cms.string(relBase+'/src/FWLJMET/LJMet/data/DeepCSV_94XSF_V3_B_F.csv'),
+            DeepCSVSubjetfile        = cms.string(relBase+'/src/FWLJMET/LJMet/data/subjet_DeepCSV_94XSF_V3_B_F.csv'),
+            BTagUncertUp             = cms.bool(False), # no longer needed, but can still be utilized. Keep false as default.
+            BTagUncertDown           = cms.bool(False), # no longer needed, but can still be utilized. Keep false as default.
+            MistagUncertUp           = cms.bool(False), # no longer needed, but can still be utilized. Keep false as default.
+            MistagUncertDown          = cms.bool(False), # no longer needed, but can still be utilized. Keep false as default.
 
 
 	),


### PR DESCRIPTION
Update/Note:
- Now Btagging, isJetTagged method which applies btag SF, is all wrapped in BTagSFUtill class.
- Selector and Calc which want to do BTagging needs to create this class. 
- Now each calculator needs to supply its own Btag parameters which allows the flexibillity of doing different btagging for different calculators/selector. 