### PR TITLE
Making isMc as member variable of JetMETCorrHelper

### DIFF
--- a/LJMet/interface/JetMETCorrHelper.h
+++ b/LJMet/interface/JetMETCorrHelper.h
@@ -25,15 +25,14 @@ class JetMETCorrHelper{
 
     public:
     	JetMETCorrHelper();
-    	JetMETCorrHelper(const edm::ParameterSet& iConfig, bool isMc);
+    	JetMETCorrHelper(const edm::ParameterSet& iConfig);
     	
-    	void Initialize(const edm::ParameterSet& iConfig, bool isMc);
+    	void Initialize(const edm::ParameterSet& iConfig);
         
         void SetFacJetCorr(edm::EventBase const & event);
         
         TLorentzVector correctJet(const pat::Jet & jet,
 						  edm::Event const & event,
-						  bool isMc,
 						  edm::EDGetTokenT<double> rhoJetsToken,
 						  bool doAK8Corr=false,
 						  bool reCorrectJet=false,
@@ -42,7 +41,6 @@ class JetMETCorrHelper{
 						  
 		pat::Jet correctJetReturnPatJet(const pat::Jet & jet,
 								edm::Event const & event,
-								bool isMc,
 								edm::EDGetTokenT<double> rhoJetsToken,
 								bool doAK8Corr=false,
 								bool reCorrectJet=false,
@@ -50,7 +48,6 @@ class JetMETCorrHelper{
 								
 		TLorentzVector correctMet(const pat::MET & met, 
 						  edm::Event const & event,
-						  bool isMc, 
 						  edm::EDGetTokenT<double> rhoJetsToken,
 						  std::vector<edm::Ptr<pat::Jet>> vAllJets,
 						  bool reCorrectjet = false, 
@@ -60,13 +57,14 @@ class JetMETCorrHelper{
 						  
 		TLorentzVector correctJetForMet(const pat::Jet & jet, 
 								edm::Event const & event,
-								bool isMc, 
 								edm::EDGetTokenT<double> rhoJetsToken,
 								unsigned int syst = 0);
 
     private:
             
         bool debug;
+
+        bool isMc;
 
         std::string mLegend = "\t[JetMETCorrHelper]: ";
     

--- a/LJMet/plugins/JetMETCorrHelper.cc
+++ b/LJMet/plugins/JetMETCorrHelper.cc
@@ -9,18 +9,20 @@ JetMETCorrHelper::JetMETCorrHelper()
     if(debug) std::cout << mLegend << "Creating JetMETCorrHelper object." << std::endl;
 }
 
-JetMETCorrHelper::JetMETCorrHelper(const edm::ParameterSet& iConfig, bool isMc)
+JetMETCorrHelper::JetMETCorrHelper(const edm::ParameterSet& iConfig)
 {
-    Initialize(iConfig,isMc);
+    Initialize(iConfig);
 }
 
 
-void JetMETCorrHelper::Initialize(const edm::ParameterSet& iConfig, bool isMc){
+void JetMETCorrHelper::Initialize(const edm::ParameterSet& iConfig){
 
     //JET CORRECTION  initialization
     std::cout << mLegend << "Initializing JetMETCorrHelper object." << std::endl;
 
     debug              = iConfig.getParameter<bool>("debug");
+
+    isMc               = iConfig.getParameter<bool>("isMc");
 
     std::string JEC_txtfile              = iConfig.getParameter<std::string>("JEC_txtfile");
     std::string JERSF_txtfile            = iConfig.getParameter<std::string>("JERSF_txtfile");
@@ -185,14 +187,13 @@ void JetMETCorrHelper::SetFacJetCorr(edm::EventBase const & event)
 
 TLorentzVector JetMETCorrHelper::correctJet(const pat::Jet & jet,
                                                  edm::Event const & event,
-                                                 bool isMc,
                                                  edm::EDGetTokenT<double> rhoJetsToken,
                                                  bool doAK8Corr,
                                                  bool reCorrectJet,
                                                  unsigned int syst)
 {
 
-  pat::Jet correctedJet = correctJetReturnPatJet(jet, event, isMc, rhoJetsToken, doAK8Corr, reCorrectJet, syst);
+  pat::Jet correctedJet = correctJetReturnPatJet(jet, event, rhoJetsToken, doAK8Corr, reCorrectJet, syst);
 
   TLorentzVector jetP4;
   jetP4.SetPtEtaPhiM(correctedJet.pt(), correctedJet.eta(),correctedJet.phi(), correctedJet.mass() ); // Should this use SetPtEtaPhiE ? -- Mar 19, 2019.
@@ -203,7 +204,6 @@ TLorentzVector JetMETCorrHelper::correctJet(const pat::Jet & jet,
 
 pat::Jet JetMETCorrHelper::correctJetReturnPatJet(const pat::Jet & jet,
                                                        edm::Event const & event,
-                                                       bool isMc,
                                                        edm::EDGetTokenT<double> rhoJetsToken,
                                                        bool doAK8Corr,
                                                        bool reCorrectJet,
@@ -385,7 +385,6 @@ pat::Jet JetMETCorrHelper::correctJetReturnPatJet(const pat::Jet & jet,
 
 TLorentzVector JetMETCorrHelper::correctMet(const pat::MET & met,
                                                  edm::Event const & event,
-                                                 bool isMc,
                                                  edm::EDGetTokenT<double> rhoJetsToken,
                                                  std::vector<edm::Ptr<pat::Jet>> vAllJets,
                                                  bool reCorrectjet,
@@ -397,7 +396,7 @@ TLorentzVector JetMETCorrHelper::correctMet(const pat::MET & met,
     if ( reCorrectjet ) {
         for (std::vector<edm::Ptr<pat::Jet> >::const_iterator ijet = vAllJets.begin(); ijet != vAllJets.end(); ++ijet) {
             if (!useHF && fabs((**ijet).eta())>2.6) continue;
-            TLorentzVector lv = correctJetForMet(**ijet, event, isMc, rhoJetsToken, syst);
+            TLorentzVector lv = correctJetForMet(**ijet, event, rhoJetsToken, syst);
             correctedMET_px += lv.Px();
             correctedMET_py += lv.Py();
         }
@@ -416,7 +415,6 @@ TLorentzVector JetMETCorrHelper::correctMet(const pat::MET & met,
 
 TLorentzVector JetMETCorrHelper::correctJetForMet(const pat::Jet & jet, 
                                                        edm::Event const & event,
-                                                       bool isMc,
                                                        edm::EDGetTokenT<double> rhoJetsToken,
                                                        unsigned int syst)
 {

--- a/LJMet/plugins/MultiLepCalc.cc
+++ b/LJMet/plugins/MultiLepCalc.cc
@@ -177,7 +177,7 @@ int MultiLepCalc::BeginJob(edm::ConsumesCollector && iC)
 	JERup                    = mPset.getParameter<bool>("JERup");
 	JERdown                  = mPset.getParameter<bool>("JERdown");
 	doAllJetSyst             = mPset.getParameter<bool>("doAllJetSyst");
-	JetMETCorr.Initialize(mPset,isMc);
+	JetMETCorr.Initialize(mPset);
 
 	//BTAG parameter initialization
 	mBtagSfUtil.Initialize(mPset);
@@ -1207,7 +1207,7 @@ void MultiLepCalc::AnalyzeMET(edm::Event const & event, BaseEventSelector * sele
 
             if (!doAllJetSyst) break;
 
-            TLorentzVector corrMET = JetMETCorr.correctMet(*pMet, event, isMc, rhoJetsToken, vAllJets, doNewJEC, corri);
+            TLorentzVector corrMET = JetMETCorr.correctMet(*pMet, event, rhoJetsToken, vAllJets, doNewJEC, corri);
 
             if(corrMET.Pt()>0) {
                 _corr_met.push_back(corrMET.Pt());
@@ -1251,7 +1251,7 @@ void MultiLepCalc::AnalyzeMET(edm::Event const & event, BaseEventSelector * sele
         _metnohf = metnohf->p4().pt();
         _metnohf_phi = metnohf->p4().phi();
 
-        TLorentzVector corrMETNOHF = JetMETCorr.correctMet(*metnohf, event, isMc, rhoJetsToken, vAllJets, doNewJEC, syst, useHF);
+        TLorentzVector corrMETNOHF = JetMETCorr.correctMet(*metnohf, event, rhoJetsToken, vAllJets, doNewJEC, syst, useHF);
         //std::cout<<(selector->GetCleanedCorrMet()).Pt()<<std::endl;
         if(corrMETNOHF.Pt()>0) {
 	  _corr_metnohf = corrMETNOHF.Pt();
@@ -1278,7 +1278,7 @@ void MultiLepCalc::AnalyzeMET(edm::Event const & event, BaseEventSelector * sele
         _metmod = metmod->p4().pt();
         _metmod_phi = metmod->p4().phi();
 
-        TLorentzVector corrMETMOD = JetMETCorr.correctMet(*metmod, event, isMc, rhoJetsToken, vAllJets, doNewJEC, syst, useHF);
+        TLorentzVector corrMETMOD = JetMETCorr.correctMet(*metmod, event, rhoJetsToken, vAllJets, doNewJEC, syst, useHF);
         //std::cout<<(selector->GetCleanedCorrMet()).Pt()<<std::endl;
         if(corrMETMOD.Pt()>0) {
 	  _corr_metmod = corrMETMOD.Pt();

--- a/LJMet/plugins/MultiLepEventSelector.cc
+++ b/LJMet/plugins/MultiLepEventSelector.cc
@@ -285,7 +285,7 @@ void MultiLepEventSelector::BeginJob( const edm::ParameterSet& iConfig, edm::Con
     max_jet                  = selectorConfig.getParameter<int>("max_jet");
     leading_jet_pt           = selectorConfig.getParameter<double>("leading_jet_pt");
     //JET CORRECTION  initialization
-    JetMETCorr.Initialize(selectorConfig,isMc);
+    JetMETCorr.Initialize(selectorConfig);
 
     //BTAG
     btag_cuts          = selectorConfig.getParameter<bool>("btag_cuts");  // this is currently not used anywhere but could be useful in the future. -- Mar 19, 2019.  
@@ -1166,14 +1166,14 @@ bool MultiLepEventSelector::JetSelection(edm::Event const & event, pat::strbitse
 			  if ( (*_i_const).key() == muDaughters[muI].key() ) {
 				tmpJet.setP4( tmpJet.p4() - muDaughters[muI]->p4() );
 				if (debug) std::cout << "  Cleaned Jet : pT = " << tmpJet.pt() << " eta = " << tmpJet.eta() << " phi = " << tmpJet.phi() << std::endl;
-				jetP4 = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet, syst); //THIS SEEMS REDUNDANT WITH correctJetReturnPatJet METHOD, CAN CALCULATE P4 FROM OUTPUT OF correctJetReturnPatJet RATHER THAN DOING EXACTLY EVERYTHING correctJetReturnPatJet IS DOING. FIX!!!! -- MAR 15,2019
+				jetP4 = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet, syst); //THIS SEEMS REDUNDANT WITH correctJetReturnPatJet METHOD, CAN CALCULATE P4 FROM OUTPUT OF correctJetReturnPatJet RATHER THAN DOING EXACTLY EVERYTHING correctJetReturnPatJet IS DOING. FIX!!!! -- MAR 15,2019
 /*				if (mbPar["doAllJetSyst"]) {
-				  jetP4_jesup = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,1);
-				  jetP4_jesdn = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,2);
-				  jetP4_jerup = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,3);
-				  jetP4_jerdn = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,4);
+				  jetP4_jesup = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet,1);
+				  jetP4_jesdn = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet,2);
+				  jetP4_jerup = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet,3);
+				  jetP4_jerdn = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet,4);
 				}*/
-				corrJet = JetMETCorr.correctJetReturnPatJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet, syst); //THIS SEEMS REDUNDANT WITH correctJet METHOD ! FIX !!!
+				corrJet = JetMETCorr.correctJetReturnPatJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet, syst); //THIS SEEMS REDUNDANT WITH correctJet METHOD ! FIX !!!
 				if (debug) std::cout << "Corrected Jet : pT = " << jetP4.Pt() << " eta = " << jetP4.Eta() << " phi = " << jetP4.Phi() << std::endl;
 				_cleaned = true;
 				muDaughters.erase( muDaughters.begin()+muI );
@@ -1202,14 +1202,14 @@ bool MultiLepEventSelector::JetSelection(edm::Event const & event, pat::strbitse
 			  if ( (*_i_const).key() == elDaughters[elI].key() ) {
 				tmpJet.setP4( tmpJet.p4() - elDaughters[elI]->p4() );
 				if (debug) std::cout << "  Cleaned Jet : pT = " << tmpJet.pt() << " eta = " << tmpJet.eta() << " phi = " << tmpJet.phi() << std::endl;
-				jetP4 = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet, syst); //THIS SEEMS REDUNDANT WITH correctJetReturnPatJet METHOD, CAN CALCULATE P4 FROM OUTPUT OF correctJetReturnPatJet RATHER THAN DOING EXACTLY EVERYTHING correctJetReturnPatJet IS DOING. FIX!!!! -- MAR 15,2019
+				jetP4 = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet, syst); //THIS SEEMS REDUNDANT WITH correctJetReturnPatJet METHOD, CAN CALCULATE P4 FROM OUTPUT OF correctJetReturnPatJet RATHER THAN DOING EXACTLY EVERYTHING correctJetReturnPatJet IS DOING. FIX!!!! -- MAR 15,2019
 /*				if (mbPar["doAllJetSyst"]) {
-				  jetP4_jesup = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,1);
-				  jetP4_jesdn = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,2);
-				  jetP4_jerup = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,3);
-				  jetP4_jerdn = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,4);
+				  jetP4_jesup = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet,1);
+				  jetP4_jesdn = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet,2);
+				  jetP4_jerup = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet,3);
+				  jetP4_jerdn = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet,4);
 				}*/
-				corrJet = JetMETCorr.correctJetReturnPatJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet, syst); //THIS SEEMS REDUNDANT WITH correctJet METHOD ! FIX!!!! -- MAR 15,2019
+				corrJet = JetMETCorr.correctJetReturnPatJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet, syst); //THIS SEEMS REDUNDANT WITH correctJet METHOD ! FIX!!!! -- MAR 15,2019
 				if (debug) std::cout << "Corrected Jet : pT = " << jetP4.Pt() << " eta = " << jetP4.Eta() << " phi = " << jetP4.Phi() << std::endl;
 				_cleaned = true;
 				elDaughters.erase( elDaughters.begin()+elI );
@@ -1222,14 +1222,14 @@ bool MultiLepEventSelector::JetSelection(edm::Event const & event, pat::strbitse
     }
 
     if (!_cleaned) {
-      jetP4 = JetMETCorr.correctJet(*_ijet, event, isMc, rhoJetsToken, isAK8, reCorrectJet, syst);
+      jetP4 = JetMETCorr.correctJet(*_ijet, event, rhoJetsToken, isAK8, reCorrectJet, syst);
 /*      if (mbPar["doAllJetSyst"]) {
-		jetP4_jesup = JetMETCorr.correctJet(*_ijet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,1);
-		jetP4_jesdn = JetMETCorr.correctJet(*_ijet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,2);
-		jetP4_jerup = JetMETCorr.correctJet(*_ijet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,3);
-		jetP4_jerdn = JetMETCorr.correctJet(*_ijet, event, isMc, rhoJetsToken, isAK8, reCorrectJet,4);
+		jetP4_jesup = JetMETCorr.correctJet(*_ijet, event, rhoJetsToken, isAK8, reCorrectJet,1);
+		jetP4_jesdn = JetMETCorr.correctJet(*_ijet, event, rhoJetsToken, isAK8, reCorrectJet,2);
+		jetP4_jerup = JetMETCorr.correctJet(*_ijet, event, rhoJetsToken, isAK8, reCorrectJet,3);
+		jetP4_jerdn = JetMETCorr.correctJet(*_ijet, event, rhoJetsToken, isAK8, reCorrectJet,4);
       }*/
-      corrJet = JetMETCorr.correctJetReturnPatJet(*_ijet, event, isMc, rhoJetsToken, isAK8, reCorrectJet, syst);
+      corrJet = JetMETCorr.correctJetReturnPatJet(*_ijet, event, rhoJetsToken, isAK8, reCorrectJet, syst);
     }
 
     _isTagged = mBtagSfUtil.isJetTagged(*_ijet, jetP4, event, isMc);
@@ -1415,8 +1415,8 @@ void MultiLepEventSelector::AK8JetSelection(edm::Event const & event)
 			  if ( (*_i_const).key() == muDaughters[muI].key() ) {
 				tmpJet.setP4( tmpJet.p4() - muDaughters[muI]->p4() );
 				if (debug) std::cout << "  Cleaned Jet : pT = " << tmpJet.pt() << " eta = " << tmpJet.eta() << " phi = " << tmpJet.phi() << " mass = " << tmpJet.mass() << std::endl;
-				jetP4 = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet);
-				corrJet = JetMETCorr.correctJetReturnPatJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet);
+				jetP4 = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet);
+				corrJet = JetMETCorr.correctJetReturnPatJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet);
 				if (debug) std::cout << "Corrected Jet : pT = " << jetP4.Pt() << " eta = " << jetP4.Eta() << " phi = " << jetP4.Phi() << " mass = " << jetP4.M() << std::endl;
 				_cleaned = true;
 				muDaughters.erase( muDaughters.begin()+muI );
@@ -1445,8 +1445,8 @@ void MultiLepEventSelector::AK8JetSelection(edm::Event const & event)
 			  if ( (*_i_const).key() == elDaughters[elI].key() ) {
 				tmpJet.setP4( tmpJet.p4() - elDaughters[elI]->p4() );
 				if (debug) std::cout << "  Cleaned Jet : pT = " << tmpJet.pt() << " eta = " << tmpJet.eta() << " phi = " << tmpJet.phi() << " mass = " << tmpJet.mass() << std::endl;
-				jetP4 = JetMETCorr.correctJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet);
-				corrJet = JetMETCorr.correctJetReturnPatJet(tmpJet, event, isMc, rhoJetsToken, isAK8, reCorrectJet);
+				jetP4 = JetMETCorr.correctJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet);
+				corrJet = JetMETCorr.correctJetReturnPatJet(tmpJet, event, rhoJetsToken, isAK8, reCorrectJet);
 				if (debug) std::cout << "Corrected Jet : pT = " << jetP4.Pt() << " eta = " << jetP4.Eta() << " phi = " << jetP4.Phi() << " mass = " << jetP4.M() << std::endl;
 				_cleaned = true;
 				elDaughters.erase( elDaughters.begin()+elI );
@@ -1459,8 +1459,8 @@ void MultiLepEventSelector::AK8JetSelection(edm::Event const & event)
     }
 
     if (!_cleaned) {
-      jetP4 = JetMETCorr.correctJet(*_ijet, event, isMc, rhoJetsToken, isAK8, reCorrectJet);
-      corrJet = JetMETCorr.correctJetReturnPatJet(*_ijet, event, isMc, rhoJetsToken, isAK8, reCorrectJet);
+      jetP4 = JetMETCorr.correctJet(*_ijet, event, rhoJetsToken, isAK8, reCorrectJet);
+      corrJet = JetMETCorr.correctJetReturnPatJet(*_ijet, event, rhoJetsToken, isAK8, reCorrectJet);
     }
 
     // jet cuts //NOTE: THIS IDEALLY SHOULDN'T BE HARD CODED -- Mar 14, 2019
@@ -1561,7 +1561,7 @@ bool MultiLepEventSelector::METSelection(edm::Event const & event)
 	  bool passMaxMET = false;
 	  if ( pMet.isNonnull() && pMet.isAvailable() ) {
 	    pat::MET const & met = mhMet->at(0);
-	    TLorentzVector corrMET = JetMETCorr.correctMet(met,event,isMc,rhoJetsToken,vAllJets,reCorrectJet,syst);
+	    TLorentzVector corrMET = JetMETCorr.correctMet(met,event,rhoJetsToken,vAllJets,reCorrectJet,syst);
 
 	    //save to EventSelector object variable.
 	    correctedMET_p4 = corrMET;


### PR DESCRIPTION
Notes:
- Previously, "isMc" had to be passed as a 2nd argument when initializing JetMETCorrHelper, and "isMc" is also arguments for all the methods in JetMETCorrHelper.
- "isMc" is now made to be a member variable of JetMETCorrHelper, and it is no longer an argument in the methods. 
- The changes has been propagated in MultiLepEventSelector and MultiLepCalc where JetMETCorrHelper is initiated and where the methods are called.